### PR TITLE
fix(table) fixed filterTableItems crash

### DIFF
--- a/src/RadarTechno/ClientApp/src/DataTable/DataTable.action.spec.ts
+++ b/src/RadarTechno/ClientApp/src/DataTable/DataTable.action.spec.ts
@@ -219,4 +219,23 @@ describe('dataTable action test', () => {
     expect(tablePaging).toEqual(state.paging);
     expect(numberPages).toEqual(1);
   });
+
+  test('filterTableItems with item missing the filter key returns empty result', () => {
+    const items = [{
+      updateDate:'2018-08-23T14:41:36.328Z',
+      id:'5823926b69170e15d895fda8',
+      version:0,
+      category:'frameworks',
+      name:'Node.JS2',
+      scope:'',
+      key:'node.js2',
+    }];
+    state.paging = {numberItems: 0, page: 1};
+    state.sort = {sortBy: 'unknown', reverse: false};
+    state.filters = {'unknown': 'key'};
+    const {tableItems, tablePaging, numberPages} = filterTableItems(items, state);
+    expect(tableItems).toEqual([]);
+    expect(tablePaging).toEqual(state.paging);
+    expect(numberPages).toEqual(1);
+  });
 });

--- a/src/RadarTechno/ClientApp/src/DataTable/DataTable.action.ts
+++ b/src/RadarTechno/ClientApp/src/DataTable/DataTable.action.ts
@@ -57,10 +57,10 @@ export const filterTableItems = (items: object[], state: IState) => {
       if(state.filters[key] && state.filters[key] !== '') {
         tableItems = tableItems.filter(item =>
           item[key] != null && 
-            (item[key].toString().toLowerCase().replace(/\s/g, '')
+            ((item[key].toString().toLowerCase().replace(/\s/g, '')
               .includes(state.filters[key].toString().toLowerCase().replace(/\s/g, '-')))
             || (item[key].toString().toLowerCase()
-              .includes(state.filters[key].toString().toLowerCase()))
+              .includes(state.filters[key].toString().toLowerCase())))
         );
       }
     });


### PR DESCRIPTION
fixed a crash if item doesn't have the filtered key

## Related issue

Crash in array filter

### Reference to the issue

https://github.com/axa-group/radar/issues/48

### Description of the issue

`Your description`

### Person(s) for reviewing proposed changes

`You can add @mention here`

## Pull Request Checklist

- [ ] I ran `sh dotnet test` locally and tests are accepted
- [ ] I ran `sh npm run test` in `src/RadarTechno/ClientApp` locally and tests are accepted
- [ ] I have added/updated tests for any new behavior.
- [ ] I have added/updated the storybook for any new or updated React component.
- [ ] If there is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
